### PR TITLE
Custom SQL Queries

### DIFF
--- a/app/controllers/auctions_controller.rb
+++ b/app/controllers/auctions_controller.rb
@@ -10,7 +10,6 @@ class AuctionsController < ApplicationController
   end
 
   def show_detail
-
     sql = "SELECT
     auctions.id AS auction_id,
     auctions.title,
@@ -30,5 +29,15 @@ class AuctionsController < ApplicationController
 
     @result = ActiveRecord::Base.connection.execute(sql)
     render json: @result
+  end
+
+  def bid_count
+  sql = "SELECT auctions.title, COUNT(*)
+  FROM auctions
+  LEFT JOIN bids ON auctions.id=bids.auction_id
+  GROUP BY auctions.id"
+
+  @result = ActiveRecord::Base.connection.execute(sql)
+  render json: @result
   end
 end

--- a/app/controllers/auctions_controller.rb
+++ b/app/controllers/auctions_controller.rb
@@ -33,9 +33,9 @@ class AuctionsController < ApplicationController
 
   def bid_count
     sql = "SELECT auctions.title, COUNT(*)
-  FROM auctions
-  LEFT JOIN bids ON auctions.id=bids.auction_id
-  GROUP BY auctions.id"
+    FROM auctions
+    LEFT JOIN bids ON auctions.id=bids.auction_id
+    GROUP BY auctions.id"
 
     @result = ActiveRecord::Base.connection.execute(sql)
     render json: @result

--- a/app/controllers/auctions_controller.rb
+++ b/app/controllers/auctions_controller.rb
@@ -8,4 +8,27 @@ class AuctionsController < ApplicationController
     auction = Auction.find(params[:id])
     render json: auction
   end
+
+  def show_detail
+
+    sql = "SELECT
+    auctions.id AS auction_id,
+    auctions.title,
+    auctions.created_at AS auction_created_at,
+    COALESCE(bids.price, auctions.starting_price) AS price,
+    seller.name AS seller_name,
+    bidder.name AS bidder_name
+    FROM auctions
+      LEFT JOIN (
+        SELECT auction_id, MAX(created_at) AS created_at FROM bids GROUP BY auction_id
+      ) high_bid ON auctions.id=high_bid.auction_id
+    LEFT JOIN bids ON bids.auction_id=auctions.id AND bids.created_at=high_bid.created_at
+    JOIN users seller ON auctions.user_id=seller.id
+    LEFT JOIN users bidder ON bids.id=bidder.id
+    ORDER BY auctions.id
+    "
+
+    @result = ActiveRecord::Base.connection.execute(sql)
+    render json: @result
+  end
 end

--- a/app/controllers/auctions_controller.rb
+++ b/app/controllers/auctions_controller.rb
@@ -32,12 +32,12 @@ class AuctionsController < ApplicationController
   end
 
   def bid_count
-  sql = "SELECT auctions.title, COUNT(*)
+    sql = "SELECT auctions.title, COUNT(*)
   FROM auctions
   LEFT JOIN bids ON auctions.id=bids.auction_id
   GROUP BY auctions.id"
 
-  @result = ActiveRecord::Base.connection.execute(sql)
-  render json: @result
+    @result = ActiveRecord::Base.connection.execute(sql)
+    render json: @result
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,4 +8,17 @@ class UsersController < ApplicationController
     user = User.find(params[:id])
     render json: user
   end
+
+  def top
+    sql = "SELECT bids.user_id, users.name, users.created_at, COUNT(*)
+    FROM bids
+    JOIN users ON bids.user_id=users.id
+    GROUP BY bids.user_id, users.id
+    HAVING COUNT(*) > 1
+    ORDER BY COUNT(*) DESC
+    LIMIT #{params[:count]}"
+
+    @result = ActiveRecord::Base.connection.execute(sql)
+    render json: @result
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   get 'users' => 'users#index'
   get 'users/:id' => 'users#show'
   get 'auctions' => 'auctions#index'
+  get 'auctions/all/details' => 'auctions#show_detail'
   get 'auctions/:id' => 'auctions#show'
   post 'auctions/:auction_id/bid' => 'bids#create'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   get 'user/me' => 'secure_users#me'
   get 'users' => 'users#index'
   get 'users/:id' => 'users#show'
+  get 'users/top/:count' => 'users#top'
   get 'auctions' => 'auctions#index'
   get 'auctions/all/details' => 'auctions#show_detail'
   get 'auctions/:id' => 'auctions#show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,6 @@ Rails.application.routes.draw do
   get 'auctions' => 'auctions#index'
   get 'auctions/all/details' => 'auctions#show_detail'
   get 'auctions/:id' => 'auctions#show'
+  get 'auctions/bids/count' => 'auctions#bid_count'
   post 'auctions/:auction_id/bid' => 'bids#create'
 end

--- a/lib/tasks/DeleteAuctions.rake
+++ b/lib/tasks/DeleteAuctions.rake
@@ -1,0 +1,18 @@
+desc 'Delete auctions with no bids that are older than 1 week'
+task :delete_old_auctions do
+  @connection = ActiveRecord::Base.establish_connection(
+    adapter: 'postgresql',
+    host: 'localhost',
+    database: 'junk4dollars_development'
+  )
+
+  sql = '
+  DELETE
+  FROM auctions
+    WHERE id NOT IN ( SELECT auction_id FROM bids )
+      AND Date(auctions.created_at) < CURRENT_DATE - 7;
+  '
+
+  result = ActiveRecord::Base.connection.delete(sql)
+  p result
+end

--- a/lib/tasks/DeleteAuctions.rake
+++ b/lib/tasks/DeleteAuctions.rake
@@ -1,11 +1,5 @@
 desc 'Delete auctions with no bids that are older than 1 week'
-task :delete_old_auctions do
-  @connection = ActiveRecord::Base.establish_connection(
-    adapter: 'postgresql',
-    host: 'localhost',
-    database: 'junk4dollars_development'
-  )
-
+task delete_old_auctions: :environment do
   sql = '
   DELETE
   FROM auctions

--- a/test/controllers/auctions_controller_test.rb
+++ b/test/controllers/auctions_controller_test.rb
@@ -154,10 +154,4 @@ class AuctionsControllerTest < ActionDispatch::IntegrationTest
     assert_equal auction.title, count.first[:title]
     assert_equal 3, count.first[:count]
   end
-
-  def create_bid(attributes = {})
-    @price = (@price || 100) + 1
-    default_attrs = {price: @price}
-    Bid.create!(default_attrs.merge(attributes))
-  end
 end

--- a/test/controllers/auctions_controller_test.rb
+++ b/test/controllers/auctions_controller_test.rb
@@ -111,9 +111,35 @@ class AuctionsControllerTest < ActionDispatch::IntegrationTest
     assert_nil auction_response[:bid]
   end
 
-  def create_bid(atributes = {})
+  test '/auctions/details should return the price as the highest bid if available' do
+    assert_equal 0, User.count
+    assert_equal 0, Auction.count
+    user = User.create!(name: 'Foo', auth0_id: 'auth0|bar')
+    assert_equal 1, User.count
+
+    auction_to_create = {
+      title: 'Mustang !?!?',
+      description: '1968 Ford Mustang',
+      starting_price: 1_200_000,
+      ends_at: 10.days.from_now.strftime('%FT%TZ'),
+      user_id: user.id
+    }
+
+    auction = Auction.create!(auction_to_create)
+
+    assert_equal 1, Auction.count
+
+    bid = create_bid(user_id: user.id, auction_id: auction.id)
+
+    get '/auctions/all/details'
+    auction_response = JSON.parse(@response.body, symbolize_names: true)
+
+    assert_equal bid.price, auction_response[0][:price]
+  end
+
+  def create_bid(attributes = {})
     @price = (@price || 100) + 1
     default_attrs = {price: @price}
-    Bid.create!(default_attrs.merge(atributes))
+    Bid.create!(default_attrs.merge(attributes))
   end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -38,4 +38,48 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_equal response_names, users.map {|user| user[:name]}
     assert_equal 2, users_response.count
   end
+
+  test '/users/top/:count should retrieve the top users by number of bids' do
+
+    users_to_create = [
+      {name: 'John', auth0_id: '001'},
+      {name: 'Polly', auth0_id: '002'},
+      {name: 'Quinn', auth0_id: '003'},
+      {name: 'Ignacio', auth0_id: '004'},
+      {name: 'Eric', auth0_id: '005'}
+    ]
+
+    created_users = users_to_create.map { |user| User.create(user)}
+
+    auction_to_create = {
+      title: 'Mustang',
+      description: '1968 Ford Mustang',
+      starting_price: 1_200_000,
+      ends_at: 10.days.from_now.strftime('%FT%TZ'),
+      user_id: created_users[4].id
+    }
+
+    auction = Auction.create!(auction_to_create)
+
+    create_bid(user_id: created_users[0].id, auction_id: auction.id) # John     (1)
+    create_bid(user_id: created_users[1].id, auction_id: auction.id) # Polly    (1)
+    create_bid(user_id: created_users[0].id, auction_id: auction.id) # John     (2)
+    create_bid(user_id: created_users[2].id, auction_id: auction.id) # Quinn    (1)
+    create_bid(user_id: created_users[0].id, auction_id: auction.id) # John     (3)
+    create_bid(user_id: created_users[3].id, auction_id: auction.id) # Ignacio  (1)
+    create_bid(user_id: created_users[2].id, auction_id: auction.id) # Quinn    (2)
+    create_bid(user_id: created_users[3].id, auction_id: auction.id) # Ignacio  (2)
+    create_bid(user_id: created_users[0].id, auction_id: auction.id) # John     (4)
+    create_bid(user_id: created_users[3].id, auction_id: auction.id) # Ignacio  (3)
+
+    get '/users/top/2'
+    top_users = JSON.parse(@response.body, symbolize_names: true)
+
+    assert_equal 2, top_users.count
+    john = top_users.select {|u| u[:name] == 'John'}.first
+    ignacio = top_users.select {|u| u[:name] == 'Ignacio'}.first
+
+    assert_equal 4, john[:count]
+    assert_equal 3, ignacio[:count]
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,4 +15,10 @@ class ActiveSupport::TestCase
   def standardize_time(string_time)
     Time.parse(string_time).strftime('%F %T')
   end
+
+  def create_bid(attributes = {})
+    @price = (@price || 100) + 1
+    default_attrs = {price: @price}
+    Bid.create!(default_attrs.merge(attributes))
+  end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added 3 new routes with custom sql queries

## Description
<!--- Describe your changes in detail -->
- `/users/top/:count` => Top X bidders based on how many bids they have made
- `/auctions/all/details` => Auction info, including seller name, bidder name (if present), and a `price`, which is either the `starting_price` or the current bid price if there are bids.
- `/auctions/bids/count` => Each auction with the number of bids on it

- Rake task `delete_old_auctions` that deletes auctions in the db that have no bids and were created over a week ago

*Note* - This was just an exercise and I'm not going to merge this, so I didn't document these routes in the readme